### PR TITLE
bug fix l1_len eda

### DIFF
--- a/00_eda.ipynb
+++ b/00_eda.ipynb
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,6 +357,16 @@
     "codes_df = joined.copy()\n",
     "codes_df['L1'] = codes_df['ICD9_CODE'].apply(lambda x: get_cat_code(x, 1, tree))\n",
     "display(codes_df[['L1', 'ICD9_CODE']].head(5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get L1_Len\n",
+    "codes_df['L1_Len'] = codes_df['L1'].apply(lambda x: len(x))"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes a few changes to the `00_eda.ipynb` file to update execution counts and add a new code cell for calculating the length of the `L1` column.

Updates to execution counts:

* [`00_eda.ipynb`](diffhunk://#diff-1a22fb586b4b2eb2972b4fc7bf25e3d68581c985c374c7d59c44f4139349be03L328-R328): Changed the `execution_count` of an existing code cell from `9` to `18`.

Addition of a new code cell:

* [`00_eda.ipynb`](diffhunk://#diff-1a22fb586b4b2eb2972b4fc7bf25e3d68581c985c374c7d59c44f4139349be03R362-R371): Added a new code cell to calculate the length of the `L1` column and store it in a new column `L1_Len`.