### PR TITLE
added icd9 coding with just az text for analytics

### DIFF
--- a/01_az_text_analytics.ipynb
+++ b/01_az_text_analytics.ipynb
@@ -29,17 +29,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "from azure.ai.textanalytics import TextAnalyticsClient\n",
     "from azure.core.credentials import AzureKeyCredential\n",
     "from dotenv import load_dotenv, find_dotenv\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
     "import pandas as pd\n",
     "import os \n",
     "import re\n",
     "import requests\n",
+    "import ast\n",
     "\n",
     "load_dotenv(find_dotenv(), override=True)\n",
     "\n",
@@ -244,6 +247,134 @@
     "\n",
     "definitions = umls_define('C0027651')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get ICD9 codes from Azure Text Analytics for Health"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get all UMLS concepts from the Azure Text Analytics API\n",
+    "def get_icd9_concept(client, documents):\n",
+    "    icd9_codes = []\n",
+    "    poller = client.begin_analyze_healthcare_entities(documents)\n",
+    "    result = poller.result()\n",
+    "\n",
+    "    docs = [doc for doc in result if not doc.is_error]\n",
+    "\n",
+    "    for idx, doc in enumerate(docs):\n",
+    "        for entity in doc.entities:\n",
+    "            if entity.data_sources and entity.category in ['SymptonOrSign', 'Diagnosis']:\n",
+    "                for data_source in entity.data_sources:\n",
+    "                    if data_source.name == \"ICD9CM\":\n",
+    "                        icd9_codes.append((data_source.entity_id, entity.text))\n",
+    "\n",
+    "    return [t[0][0:3] for t in icd9_codes]\n",
+    "\n",
+    "# TEST\n",
+    "icd9_codes = get_icd9_concept(client, [note_events['TEXT'][0]])\n",
+    "print(icd9_codes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare eval data\n",
+    "mimic_df = pd.read_csv('data/joined/dataset_single_notes_full.csv.gz')\n",
+    "print(f\"Total shape: {mimic_df.shape}\")\n",
+    "print(mimic_df.dtypes)\n",
+    "\n",
+    "# Take a subsample for evaluation\n",
+    "mimic_df = mimic_df.sample(50, replace=False, random_state=123)\n",
+    "display(mimic_df.head(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tqdm.pandas()\n",
+    "mimic_df['az_ta_icd9'] = mimic_df['TEXT'].progress_apply(lambda x: get_icd9_concept(client, [x]))\n",
+    "display(mimic_df.head(5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate results\n",
+    "\n",
+    "def recall_score(truth, generated):\n",
+    "    actual_list = ast.literal_eval(truth)\n",
+    "\n",
+    "    similar = len(set(actual_list) & set(generated))\n",
+    "    return similar / len(actual_list)\n",
+    "\n",
+    "def precision_score(truth, generated):\n",
+    "    actual_list = ast.literal_eval(truth)\n",
+    "\n",
+    "    if len(generated) == 0:\n",
+    "        return 0\n",
+    "\n",
+    "    similar = len(set(actual_list) & set(generated))\n",
+    "\n",
+    "    return similar / len(generated)\n",
+    "\n",
+    "def f1_score(truth, generated):\n",
+    "    precision = precision_score(truth, generated)\n",
+    "    recall = recall_score(truth, generated)\n",
+    "\n",
+    "    if precision + recall == 0:\n",
+    "        return 0\n",
+    "    else:\n",
+    "        return 2 * (precision * recall) / (precision + recall)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grade final code outputs\n",
+    "\n",
+    "results = pd.DataFrame()\n",
+    "\n",
+    "# results['ICD9_CODE'] = mimic_df['ICD9_CODE'].apply(format_icd9)\n",
+    "results['Recall'] = mimic_df.apply(lambda x: recall_score(x['ICD9_CODE'], x['az_ta_icd9']), axis=1)\n",
+    "results['Precision'] = mimic_df.apply(lambda x: precision_score(x['ICD9_CODE'], x['az_ta_icd9']), axis=1)\n",
+    "results['F1 Score'] = mimic_df.apply(lambda x: f1_score(x['ICD9_CODE'], x['az_ta_icd9']), axis=1)\n",
+    "\n",
+    "display(results[['Recall', 'Precision', 'F1 Score']].mean(axis=0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Observations\n",
+    "\n",
+    "1. Using Azure Text Analytics for Health for medical coding is a very viable option in certain situations. However, due to the extreme complexity of the MIMIC-III dataset it would need to be used with other methods explored in this repository to be effective for this specific dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/04b_aoai_ft.ipynb
+++ b/04b_aoai_ft.ipynb
@@ -473,7 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. In this notebook, the model exhibits state-of-the-art recall and precision on par with the existing approaches. HOWEVER, this is likely due to the fact that we are not cleaning the messy MIMIC-III notes before sending to the model. Notes likely include irrelevant information - like prior medical history - that the model classifies as an ICD9 code marker.  \n",
+    "1. In this notebook, the model exhibits state-of-the-art recall and precision on par with the existing approaches. HOWEVER, this is likely due to the fact that we are not cleaning the messy MIMIC-III notes before sending to the model. Notes likely include irrelevant information - like prior medical history - that the model classifies as an ICD9 code marker. Check out the [second notebook in this repository](./02_llm_extraction.ipynb) to review techiques to simplify MIMIC-III notes \n",
     "  \n",
     "    Note: Most [state of the art approaches](https://paperswithcode.com/sota/medical-code-prediction-on-mimic-iii) often take extreme subsamples of data to limit the problem space.   \n",
     "  \n",


### PR DESCRIPTION
This pull request includes significant updates to the `01_az_text_analytics.ipynb` and `04b_aoai_ft.ipynb` notebooks to enhance functionality and improve documentation. Key changes include adding new libraries, creating new functions for ICD9 code extraction, and updating markdown cells for better clarity.

Enhancements to `01_az_text_analytics.ipynb`:

* Added new libraries `tqdm` and `ast` to the import section for progress tracking and abstract syntax tree manipulation. (`01_az_text_analytics.ipynb`, [01_az_text_analytics.ipynbL32-R45](diffhunk://#diff-9f385b62a1155510ab1fa1834a12fb35ff9f8f49836521d00c63de9b9efe52acL32-R45))
* Introduced a new markdown cell to describe the process of getting ICD9 codes from Azure Text Analytics for Health. (`01_az_text_analytics.ipynb`, [01_az_text_analytics.ipynbR250-R377](diffhunk://#diff-9f385b62a1155510ab1fa1834a12fb35ff9f8f49836521d00c63de9b9efe52acR250-R377))
* Added a new function `get_icd9_concept` to extract ICD9 codes from documents using Azure Text Analytics API. (`01_az_text_analytics.ipynb`, [01_az_text_analytics.ipynbR250-R377](diffhunk://#diff-9f385b62a1155510ab1fa1834a12fb35ff9f8f49836521d00c63de9b9efe52acR250-R377))
* Included new cells for preparing evaluation data, applying the `get_icd9_concept` function, and evaluating the results using recall, precision, and F1 score metrics. (`01_az_text_analytics.ipynb`, [01_az_text_analytics.ipynbR250-R377](diffhunk://#diff-9f385b62a1155510ab1fa1834a12fb35ff9f8f49836521d00c63de9b9efe52acR250-R377))
* Added observations in a markdown cell to summarize the findings and potential use cases of Azure Text Analytics for Health. (`01_az_text_analytics.ipynb`, [01_az_text_analytics.ipynbR250-R377](diffhunk://#diff-9f385b62a1155510ab1fa1834a12fb35ff9f8f49836521d00c63de9b9efe52acR250-R377))

Documentation improvements in `04b_aoai_ft.ipynb`:

* Updated a markdown cell to include a reference to the second notebook for techniques on simplifying MIMIC-III notes, enhancing the clarity and guidance for users. (`04b_aoai_ft.ipynb`, [04b_aoai_ft.ipynbL476-R476](diffhunk://#diff-bbbe380787c613daeeea4d7e0eaef05d956f5893b06f8275173685a6c018b7fbL476-R476))